### PR TITLE
Fix listen arg conflict (panic in dev)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ struct ClientArgs {
     #[arg(short, long, help = "The room identifier")]
     id: String,
     #[arg(
-        short,
+        short='l',
         long,
         default_value_t = 1.0,
         help = "The volume at which to play the clicks"


### PR DESCRIPTION
A short arg conflict was fixed which caused a panic in dev.
Chose to change the volume shorthand given that the 
verbose option is currently dominant, thus hopefully
making sure that no currently running existing calls will break
after change.